### PR TITLE
Add Opera extension CTA to docs index

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -180,6 +180,13 @@
           </span>
           Chrome Extension
         </a>
+        <a class="btn btn-primary" href="https://addons.opera.com/en/extensions/details/comix-downloader/" target="_blank" rel="noopener">
+          <span class="btn-logo">
+            <img src="https://cdn.jsdelivr.net/gh/gilbarbara/logos/logos/opera.svg" alt="" width="14" height="14" onerror="this.style.display='none';this.nextElementSibling.style.display='block'">
+            <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="#ff1b2d" stroke-width="2.5" style="display:none"><ellipse cx="12" cy="12" rx="7" ry="9"/></svg>
+          </span>
+          Opera Extension
+        </a>
         <a class="btn btn-ghost" href="https://github.com/N3uralCreativity/comix-downloader" target="_blank" rel="noopener">
           <svg aria-hidden="true" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"/></svg>
           GitHub


### PR DESCRIPTION
### Motivation
- Surface the Opera extension to users by adding a direct call-to-action in the site hero so Opera users can easily find and install the extension.

### Description
- Added an `Opera Extension` button to `docs/index.html` within the hero CTA row that links to `https://addons.opera.com/en/extensions/details/comix-downloader/` and includes an Opera logo and fallback SVG.

### Testing
- No automated tests were run for this documentation change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6b224c69648320a96cec8ce2fb42df)