### PR TITLE
fix: extract chapters on Firefox for Android ("Missing host permission for the tab")

### DIFF
--- a/background.js
+++ b/background.js
@@ -1608,7 +1608,9 @@ function chapterFailurePresentation(error, options = {}) {
     } else if (diagnostic.kind === 'image_download') {
       message = 'Some chapter images could not be downloaded. Reload the Comix page and try again.';
     } else if (diagnostic.kind === 'chapter_extraction') {
-      message = 'The extension could not read this chapter. Reload the Comix page, complete any verification, and try again.';
+      message = diagnostic.code === 'CDL-EXTRACT-003'
+        ? 'The browser has not given the extension access to this site. Allow Comix Downloader to access it in the browser add-on permissions, then start the download again.'
+        : 'The extension could not read this chapter. Reload the Comix page, complete any verification, and try again.';
     } else if (diagnostic.kind === 'tab_open') {
       message = 'The background chapter page could not be opened.';
     } else if (diagnostic.kind === 'archive_build' || diagnostic.kind === 'chapter_packaging') {
@@ -2297,6 +2299,15 @@ async function handlePendingDownloadTabUpdated(tabId, changeInfo) {
   const { chapterUrl, zipName, originTabId, cfg, options } = pending;
 
   try {
+    // Same Firefox guard as Download All: the tab can report the chapter URL
+    // while still holding its initial about:blank document.
+    await waitForInjectableTab(tabId, {
+      timeoutMs: Math.min(
+        Math.max((cfg && cfg['perf.tabLoadTimeoutMs']) || 120000, 15000),
+        INJECTION_READY_TIMEOUT_MS
+      ),
+      nudge: () => chrome.tabs.update(tabId, { url: withExtractMarker(chapterUrl) }),
+    });
     const challenge = await coordinateCloudflareChallenge(tabId, {
       originTabId,
       expectedSeriesSlug: (String(chapterUrl).match(/\/title\/([^/]+)/) || [])[1] || '',
@@ -2319,7 +2330,7 @@ async function handlePendingDownloadTabUpdated(tabId, changeInfo) {
     }
 
     // Injecter le script d'extraction dans l'onglet chapitre
-    const results = await chrome.scripting.executeScript({
+    const results = await executeScriptWhenInjectable({
       target: { tabId },
       world: 'MAIN',   // share the page's Resource Timing buffer (canvas-page URLs)
       func: extractChapterImagesFromPage,
@@ -3737,6 +3748,7 @@ function diagnosticDefinition(error, requestedKind, requestedPhase) {
     if (error && error.downloadPhase) kind = 'archive_save';
     else if (/FILE_|NETWORK_|SERVER_|USER_/i.test(raw) && /save|download|interrupt|file/i.test(raw)) kind = 'archive_save';
     else if (/cloudflare|captcha|challenge|verification/i.test(raw)) kind = 'verification';
+    else if (HOST_PERMISSION_ERROR_RE.test(raw)) kind = 'chapter_extraction';
     else if (/no images?|aucune image|extract/i.test(raw)) kind = 'chapter_extraction';
     else if (/only\s+\d+\s+of\s+\d+\s+images?|image request|HTTP\s+\d{3}/i.test(raw)) kind = 'image_download';
     else if (/context invalidated|receiving end does not exist|message port closed/i.test(raw)) kind = 'runtime_connection';
@@ -3752,6 +3764,19 @@ function diagnosticDefinition(error, requestedKind, requestedPhase) {
     if (/FILE_BLOCKED|SECURITY_CHECK/i.test(raw)) return { code: 'CDL-SAVE-006', kind, phase, summary: 'The browser security check blocked the archive.' };
     if (/NETWORK_|SERVER_|timed?\s*out/i.test(raw)) return { code: 'CDL-SAVE-007', kind, phase, summary: 'The browser download manager interrupted the save.' };
     return { code: 'CDL-SAVE-001', kind, phase, summary: 'The browser could not save or confirm the archive.' };
+  }
+
+  if (kind === 'chapter_extraction') {
+    const permissionDenied = Boolean(error && error.code === 'HOST_PERMISSION_MISSING') ||
+      HOST_PERMISSION_ERROR_RE.test(raw);
+    if (permissionDenied) {
+      return {
+        code: 'CDL-EXTRACT-003',
+        kind,
+        phase,
+        summary: 'The browser has not granted the extension access to the chapter page.',
+      };
+    }
   }
 
   const definitions = {
@@ -4494,6 +4519,157 @@ function notifyTab(tabId, message) {
   chrome.tabs.sendMessage(tabId, message).catch(() => {});
 }
 
+// ── Injection readiness (Firefox / Firefox for Android) ───────────────────────
+// Chrome keeps a navigation target in `tabs.Tab.pendingUrl` and leaves `url` on
+// the document that is actually loaded. Firefox has no `pendingUrl`: it
+// publishes the target URL as `url` as soon as the navigation is requested, so
+// a freshly created background tab reports status:"complete" with the chapter
+// URL while it still holds its initial about:blank document. Injecting there
+// throws "Missing host permission for the tab" (about:blank is covered by no
+// host permission), which failed the extraction of every chapter on Firefox for
+// Android — the extraction tab is opened in the background there and pushed
+// back to the background by the mobile tab restore, so its load commits well
+// after the first "complete" event.
+//
+// Injection is therefore retried while the tab sits between documents, and is
+// only reported as a permission problem when the extension genuinely does not
+// hold the host permission for the page it is trying to read.
+const HOST_PERMISSION_ERROR_RE =
+  /missing host permission|cannot access (?:the )?(?:contents of|page)|manifest must request permission|no permission to access/i;
+const INJECTION_RETRY_BASE_MS = 200;
+const INJECTION_RETRY_MAX_MS = 1000;
+const INJECTION_READY_TIMEOUT_MS = 45000;
+// Firefox for Android can also unload a background tab under memory pressure:
+// it keeps reporting status:"complete" and its URL while holding no document at
+// all. Re-issuing the navigation once wakes it instead of waiting out the whole
+// deadline for a load that will never happen on its own.
+const INJECTION_STALLED_NUDGE_MS = 8000;
+
+function isHostPermissionError(error) {
+  return HOST_PERMISSION_ERROR_RE.test(downloadErrorText(error));
+}
+
+function injectionOriginPattern(url) {
+  try {
+    const parsed = new URL(String(url || ''));
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null;
+    return `${parsed.protocol}//${parsed.hostname}/*`;
+  } catch (_) {
+    return null;
+  }
+}
+
+// null  → not a real page yet (about:blank, empty URL): keep waiting.
+// false → the browser has not granted access to that origin: stop waiting.
+async function hasGrantedHostPermission(url) {
+  const pattern = injectionOriginPattern(url);
+  if (!pattern) return null;
+  try {
+    return await new Promise((resolve) => {
+      chrome.permissions.contains({ origins: [pattern] }, (granted) => {
+        // A pattern the browser refuses to evaluate must not be read as a
+        // denial — only an explicit "no" ends the wait.
+        if (chrome.runtime.lastError) resolve(true);
+        else resolve(!!granted);
+      });
+    });
+  } catch (_) {
+    return true;
+  }
+}
+
+// The tab kept reporting a page the extension may read while never committing a
+// document to read. Say that, rather than repeating the browser's raw
+// "Missing host permission" text, which points at the wrong problem.
+function makeInjectionNotReadyError(url) {
+  let host = '';
+  try { host = new URL(String(url || '')).hostname; } catch (_) {}
+  const error = new Error(
+    `The chapter page never finished loading in the background tab${host ? ` (${host})` : ''}.`
+  );
+  error.name = 'InjectionNotReadyError';
+  error.code = 'INJECTION_NOT_READY';
+  error.cdlKind = 'chapter_extraction';
+  return error;
+}
+
+function makeMissingHostPermissionError(url) {
+  let host = '';
+  try { host = new URL(String(url || '')).hostname; } catch (_) {}
+  const target = host || 'this site';
+  const error = new Error(
+    `The browser has not allowed the extension to read ${target}. Grant Comix Downloader ` +
+    `access to ${target} in the browser add-on permissions (Firefox: Menu → Add-ons → ` +
+    `Comix Downloader → Permissions), then start the download again.`
+  );
+  error.name = 'HostPermissionError';
+  error.code = 'HOST_PERMISSION_MISSING';
+  error.cdlKind = 'chapter_extraction';
+  return error;
+}
+
+// Returns the tab's target URL, or null when the tab itself is gone.
+async function injectionTargetUrl(tabId) {
+  try {
+    const tab = await chrome.tabs.get(tabId);
+    return String(tab && (tab.url || tab.pendingUrl) || '');
+  } catch (_) {
+    return null;
+  }
+}
+
+async function executeScriptWhenInjectable(injection, options = {}) {
+  const tabId = injection && injection.target && injection.target.tabId;
+  const startedAt = Date.now();
+  const deadline = startedAt + (Number(options.timeoutMs) || INJECTION_READY_TIMEOUT_MS);
+  const cancelled = typeof options.cancelled === 'function' ? options.cancelled : null;
+  const nudge = typeof options.nudge === 'function' ? options.nudge : null;
+  const nudgeAfterMs = Number(options.nudgeAfterMs) || INJECTION_STALLED_NUDGE_MS;
+  let nudged = false;
+
+  for (let attempt = 1; ; attempt++) {
+    if (cancelled && cancelled()) throw makeDownloadAllStoppedError();
+    try {
+      return await chrome.scripting.executeScript(injection);
+    } catch (error) {
+      if (!isHostPermissionError(error)) throw error;
+      const url = await injectionTargetUrl(tabId);
+      if (url === null) throw error; // the tab was closed — nothing left to wait for
+      if ((await hasGrantedHostPermission(url)) === false) {
+        throw makeMissingHostPermissionError(url);
+      }
+      const now = Date.now();
+      if (now >= deadline) throw makeInjectionNotReadyError(url);
+      if (nudge && !nudged && now - startedAt >= nudgeAfterMs) {
+        nudged = true;
+        try { await nudge(); } catch (_) {}
+      }
+      await new Promise((resolve) => setTimeout(
+        resolve,
+        Math.min(INJECTION_RETRY_BASE_MS * attempt, INJECTION_RETRY_MAX_MS)
+      ));
+    }
+  }
+}
+
+// Injected purely to prove the tab holds a document the extension may read.
+function probeInjectableDocument() {
+  return {
+    url: String(typeof location !== 'undefined' ? location.href || '' : ''),
+    readyState: String(document && document.readyState || ''),
+  };
+}
+
+// Resolves once the tab actually holds an injectable document, so the Cloudflare
+// probe and the extraction script never run against an uncommitted about:blank.
+async function waitForInjectableTab(tabId, options = {}) {
+  const results = await executeScriptWhenInjectable({
+    target: { tabId },
+    func: probeInjectableDocument,
+  }, options);
+  return (results && results[0] && results[0].result) || null;
+}
+
 // Cloudflare challenges must be completed by the user in their real browser
 // session. Coordinate all extraction tabs behind one visible challenge so a
 // concurrent Download All cannot open several verification pages at once.
@@ -4865,6 +5041,13 @@ async function extractFromTab(url, cfg, navigation = {}) {
       handling = true;
       try {
         clearTimeout(timer);
+        // Firefox reports the tab as complete on the chapter URL before the
+        // document commits; wait for a document the extension may actually read.
+        await waitForInjectableTab(tabId, {
+          timeoutMs: Math.min(Math.max(tabTimeout, 15000), INJECTION_READY_TIMEOUT_MS),
+          cancelled: opened.navigation.cancelled,
+          nudge: () => chrome.tabs.update(tabId, { url: withExtractMarker(url) }),
+        });
         const challenge = await coordinateCloudflareChallenge(tabId, opened.navigation);
         if (challenge.challenged) opened.navigation.challengeEncountered = true;
         if (challenge.reloaded) {
@@ -4878,7 +5061,7 @@ async function extractFromTab(url, cfg, navigation = {}) {
           return;
         }
         armTimer();
-        const results = await chrome.scripting.executeScript({
+        const results = await executeScriptWhenInjectable({
           target: { tabId },
           world: 'MAIN',   // share the page's Resource Timing buffer (canvas-page URLs)
           func:   extractChapterImagesFromPage,
@@ -4888,7 +5071,7 @@ async function extractFromTab(url, cfg, navigation = {}) {
             settleMs: cfg['perf.pageSettleMs'],
             scrollSettleMs: cfg['perf.scrollSettleMs'],
           }],
-        });
+        }, { cancelled: opened.navigation.cancelled });
         const images = results?.[0]?.result || [];
         if ((!Array.isArray(images) || images.length === 0) &&
             opened.navigation.challengeEncountered) {

--- a/tests/download-confirmation.test.js
+++ b/tests/download-confirmation.test.js
@@ -39,6 +39,12 @@ function extractFunction(name) {
   throw new Error(`Unterminated function ${name}`);
 }
 
+function extractConst(name) {
+  const marker = source.indexOf(`const ${name} =`);
+  if (marker === -1) throw new Error(`Missing const ${name}`);
+  return source.slice(marker, source.indexOf(';', marker) + 1);
+}
+
 const helperSource = [
   'downloadErrorText',
   'isDownloadCancelledError',
@@ -175,6 +181,7 @@ vm.runInContext(`
   ${extractFunction('sanitizeDiagnosticText')}
   ${extractFunction('sanitizeDiagnosticContext')}
   ${extractFunction('diagnosticHttpStatus')}
+  ${extractConst('HOST_PERMISSION_ERROR_RE')}
   ${extractFunction('diagnosticDefinition')}
   ${extractFunction('createErrorDiagnostic')}
   ${extractFunction('describeArchiveFailure')}

--- a/tests/download-session.test.js
+++ b/tests/download-session.test.js
@@ -44,6 +44,12 @@ function extractFunction(name) {
   throw new Error(`Unterminated function ${name}`);
 }
 
+function extractConst(name) {
+  const marker = source.indexOf(`const ${name} =`);
+  if (marker === -1) throw new Error(`Missing const ${name}`);
+  return source.slice(marker, source.indexOf(';', marker) + 1);
+}
+
 const context = { Date, JSON, Math, Number, String, Array, Set };
 vm.createContext(context);
 vm.runInContext(`
@@ -57,6 +63,7 @@ vm.runInContext(`
   ${extractFunction('sanitizeDiagnosticText')}
   ${extractFunction('sanitizeDiagnosticContext')}
   ${extractFunction('diagnosticHttpStatus')}
+  ${extractConst('HOST_PERMISSION_ERROR_RE')}
   ${extractFunction('diagnosticDefinition')}
   ${extractFunction('createErrorDiagnostic')}
   ${extractFunction('cloneDownloadAllOptions')}
@@ -185,6 +192,7 @@ vm.runInContext(`
   ${extractFunction('sanitizeDiagnosticText')}
   ${extractFunction('sanitizeDiagnosticContext')}
   ${extractFunction('diagnosticHttpStatus')}
+  ${extractConst('HOST_PERMISSION_ERROR_RE')}
   ${extractFunction('diagnosticDefinition')}
   ${extractFunction('createErrorDiagnostic')}
   ${extractFunction('isValidDownloadAllResumeData')}
@@ -321,6 +329,7 @@ async function runAsyncSessionChecks() {
     ${extractFunction('sanitizeDiagnosticText')}
     ${extractFunction('sanitizeDiagnosticContext')}
     ${extractFunction('diagnosticHttpStatus')}
+    ${extractConst('HOST_PERMISSION_ERROR_RE')}
     ${extractFunction('diagnosticDefinition')}
     ${extractFunction('createErrorDiagnostic')}
     ${extractFunction('isValidDownloadAllResumeData')}

--- a/tests/error-diagnostics.test.js
+++ b/tests/error-diagnostics.test.js
@@ -43,10 +43,17 @@ function extractFunction(name) {
   throw new Error(`Unterminated function ${name}`);
 }
 
+function extractConst(name) {
+  const marker = source.indexOf(`const ${name} =`);
+  if (marker === -1) throw new Error(`Missing const ${name}`);
+  return source.slice(marker, source.indexOf(';', marker) + 1);
+}
+
 const context = { Date, Error, JSON, Math, Number, Object, Set, String };
 vm.createContext(context);
 vm.runInContext(`
   function extensionVersion() { return '4.2.test'; }
+  ${extractConst('HOST_PERMISSION_ERROR_RE')}
   ${extractFunction('downloadErrorText')}
   ${extractFunction('sanitizeDiagnosticText')}
   ${extractFunction('sanitizeDiagnosticContext')}

--- a/tests/host-permission-injection.test.js
+++ b/tests/host-permission-injection.test.js
@@ -1,0 +1,341 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const source = fs.readFileSync(path.join(__dirname, '..', 'background.js'), 'utf8');
+let passed = 0;
+let failed = 0;
+
+function check(name, condition) {
+  if (condition) passed++;
+  else {
+    failed++;
+    console.error('FAIL:', name);
+  }
+}
+
+function extractFunction(name) {
+  const marker = source.indexOf(`function ${name}(`);
+  if (marker === -1) throw new Error(`Missing function ${name}`);
+  const start = source.slice(Math.max(0, marker - 6), marker) === 'async ' ? marker - 6 : marker;
+  const bodyStart = source.indexOf('{', source.indexOf(')', marker));
+  let depth = 0;
+  let quote = '';
+  let escaped = false;
+  let lineComment = false;
+  let blockComment = false;
+
+  for (let i = bodyStart; i < source.length; i++) {
+    const ch = source[i];
+    const next = source[i + 1];
+    if (lineComment) { if (ch === '\n') lineComment = false; continue; }
+    if (blockComment) { if (ch === '*' && next === '/') { blockComment = false; i++; } continue; }
+    if (quote) {
+      if (escaped) { escaped = false; continue; }
+      if (ch === '\\') { escaped = true; continue; }
+      if (ch === quote) quote = '';
+      continue;
+    }
+    if (ch === '/' && next === '/') { lineComment = true; i++; continue; }
+    if (ch === '/' && next === '*') { blockComment = true; i++; continue; }
+    if (ch === "'" || ch === '"' || ch === '`') { quote = ch; continue; }
+    if (ch === '{') depth++;
+    if (ch === '}' && --depth === 0) return source.slice(start, i + 1);
+  }
+  throw new Error(`Unterminated function ${name}`);
+}
+
+function extractConst(name) {
+  const marker = source.indexOf(`const ${name} =`);
+  if (marker === -1) throw new Error(`Missing const ${name}`);
+  const end = source.indexOf(';', marker);
+  return source.slice(marker, end + 1);
+}
+
+// The Firefox "Missing host permission for the tab" failure: the tab reports the
+// chapter URL while still holding its initial about:blank document.
+function buildHarness(options = {}) {
+  const {
+    grantedOrigins = ['*://comix.to/*', '*://comix.ws/*'],
+    tabUrl = 'https://comix.to/title/x/1-chapter-1',
+  } = options;
+  let documentUrls = options.documentUrls || ['about:blank', 'https://comix.to/title/x/1-chapter-1'];
+
+  const calls = [];
+  let injectAttempts = 0;
+  let tabClosed = false;
+  let documentIndex = 0;
+
+  const matches = (pattern, url) => {
+    const [scheme, rest] = pattern.split('://');
+    const host = rest.replace(/\/\*$/, '');
+    try {
+      const parsed = new URL(url);
+      const schemeOk = scheme === '*' || `${scheme}:` === parsed.protocol;
+      const hostOk = host.startsWith('*.')
+        ? parsed.hostname === host.slice(2) || parsed.hostname.endsWith(`.${host.slice(2)}`)
+        : parsed.hostname === host;
+      return schemeOk && hostOk;
+    } catch (_) {
+      return false;
+    }
+  };
+
+  const context = {
+    Promise, String, Number, Math, Date, Error, URL, setTimeout, clearTimeout,
+    console,
+    chrome: {
+      runtime: { lastError: null },
+      scripting: {
+        async executeScript(injection) {
+          injectAttempts++;
+          calls.push({ action: 'executeScript', tabId: injection.target.tabId });
+          if (tabClosed) throw new Error('No tab with id: 101.');
+          const current = documentUrls[Math.min(documentIndex, documentUrls.length - 1)];
+          documentIndex++;
+          const allowed = grantedOrigins.some((pattern) => matches(pattern, current));
+          if (!allowed) throw new Error('Missing host permission for the tab');
+          return [{ result: { url: current, readyState: 'complete' } }];
+        },
+      },
+      permissions: {
+        contains(query, callback) {
+          calls.push({ action: 'permissions.contains', origins: query.origins.slice() });
+          const ok = query.origins.every((requested) =>
+            grantedOrigins.some((granted) => {
+              const [, grantedHost] = granted.split('://');
+              const [, requestedHost] = requested.split('://');
+              return grantedHost === requestedHost;
+            }));
+          callback(ok);
+        },
+      },
+      tabs: {
+        async get(tabId) {
+          calls.push({ action: 'tabs.get', tabId });
+          if (tabClosed) throw new Error('No tab with id: 101.');
+          return { id: tabId, status: 'complete', url: tabUrl };
+        },
+        async update(tabId, properties) {
+          calls.push({ action: 'tabs.update', tabId, properties: { ...properties } });
+          return { id: tabId };
+        },
+      },
+    },
+  };
+  vm.createContext(context);
+  vm.runInContext(`
+    function downloadErrorText(value) {
+      if (!value) return '';
+      if (typeof value === 'string') return value;
+      return String(value.reason || value.error || value.message || value.code || value);
+    }
+    function makeDownloadAllStoppedError() {
+      const error = new Error('Download All stopped.');
+      error.code = 'DOWNLOAD_ALL_STOPPED';
+      return error;
+    }
+    ${extractConst('HOST_PERMISSION_ERROR_RE')}
+    ${extractConst('INJECTION_RETRY_BASE_MS')}
+    ${extractConst('INJECTION_RETRY_MAX_MS')}
+    ${extractConst('INJECTION_READY_TIMEOUT_MS')}
+    ${extractConst('INJECTION_STALLED_NUDGE_MS')}
+    ${extractFunction('isHostPermissionError')}
+    ${extractFunction('injectionOriginPattern')}
+    ${extractFunction('hasGrantedHostPermission')}
+    ${extractFunction('makeInjectionNotReadyError')}
+    ${extractFunction('makeMissingHostPermissionError')}
+    ${extractFunction('injectionTargetUrl')}
+    ${extractFunction('executeScriptWhenInjectable')}
+    ${extractFunction('probeInjectableDocument')}
+    ${extractFunction('waitForInjectableTab')}
+    globalThis.api = {
+      isHostPermissionError,
+      injectionOriginPattern,
+      hasGrantedHostPermission,
+      executeScriptWhenInjectable,
+      waitForInjectableTab,
+      INJECTION_READY_TIMEOUT_MS,
+      INJECTION_STALLED_NUDGE_MS,
+    };
+  `, context);
+
+  return {
+    api: context.api,
+    calls,
+    closeTab: () => { tabClosed = true; },
+    // Simulates the tab finally committing a document (e.g. after a nudge).
+    commitDocument: (url) => { documentUrls = [url]; documentIndex = 0; },
+    getInjectAttempts: () => injectAttempts,
+  };
+}
+
+function buildDiagnosticsHarness() {
+  const context = { String, Number, Math, Date, Error, console };
+  vm.createContext(context);
+  vm.runInContext(`
+    ${extractConst('HOST_PERMISSION_ERROR_RE')}
+    function downloadErrorText(value) {
+      if (!value) return '';
+      if (typeof value === 'string') return value;
+      return String(value.reason || value.error || value.message || value.code || value);
+    }
+    ${extractFunction('diagnosticHttpStatus')}
+    ${extractFunction('diagnosticDefinition')}
+    globalThis.api = { diagnosticDefinition };
+  `, context);
+  return context.api;
+}
+
+async function run() {
+  // ── Source wiring ──────────────────────────────────────────────────────────
+  check('Download All waits for an injectable document before probing Cloudflare',
+    /await waitForInjectableTab\(tabId, \{[\s\S]*?\}\);\s*\n\s*const challenge = await coordinateCloudflareChallenge\(tabId, opened\.navigation\);/
+      .test(source));
+  check('Single-chapter extraction waits for an injectable document too',
+    /await waitForInjectableTab\(tabId, \{[\s\S]*?\}\);\s*\n\s*const challenge = await coordinateCloudflareChallenge\(tabId, \{/
+      .test(source));
+  check('Both extraction injections go through the retrying helper',
+    source.split('await executeScriptWhenInjectable({').length === 4 &&
+    !/executeScript\(\{[^}]*\n\s*func:\s*extractChapterImagesFromPage/.test(source));
+  check('A stalled background tab is nudged with a fresh navigation',
+    source.includes('nudge: () => chrome.tabs.update(tabId, { url: withExtractMarker(url) })') &&
+    source.includes('nudge: () => chrome.tabs.update(tabId, { url: withExtractMarker(chapterUrl) })'));
+
+  // ── Error recognition ──────────────────────────────────────────────────────
+  const { api } = buildHarness();
+  check('Firefox wording is recognised as a host-permission failure',
+    api.isHostPermissionError(new Error('Missing host permission for the tab')));
+  check('Chromium wording is recognised as a host-permission failure',
+    api.isHostPermissionError(new Error(
+      'Cannot access contents of the page. Extension manifest must request permission to access the respective host.'
+    )));
+  check('Unrelated failures are not mistaken for host-permission failures',
+    !api.isHostPermissionError(new Error('Timeout chargement onglet')) &&
+    !api.isHostPermissionError(new Error('Aucune image trouvée dans ce chapitre')));
+
+  check('Origin patterns drop the port and keep the scheme',
+    api.injectionOriginPattern('https://comix.to/title/x/1-chapter-1?a=b#cdlx') === 'https://comix.to/*');
+  check('A tab between documents yields no origin pattern',
+    api.injectionOriginPattern('about:blank') === null &&
+    api.injectionOriginPattern('') === null);
+
+  check('A granted origin reports true, an unlisted one false, about:blank null',
+    (await api.hasGrantedHostPermission('https://comix.to/x')) === true &&
+    (await api.hasGrantedHostPermission('https://example.com/x')) === false &&
+    (await api.hasGrantedHostPermission('about:blank')) === null);
+
+  // ── Retry until the real document commits ──────────────────────────────────
+  const committing = buildHarness({
+    documentUrls: ['about:blank', 'about:blank', 'https://comix.to/title/x/1-chapter-1'],
+  });
+  const ready = await committing.api.waitForInjectableTab(101, { timeoutMs: 5000 });
+  check('Injection is retried until the chapter document commits',
+    ready && ready.url === 'https://comix.to/title/x/1-chapter-1' &&
+    committing.getInjectAttempts() === 3);
+  check('Waiting never mistakes an uncommitted tab for a permission denial',
+    committing.calls.filter((c) => c.action === 'permissions.contains').length === 2);
+
+  // ── Genuine denial ─────────────────────────────────────────────────────────
+  const denied = buildHarness({
+    grantedOrigins: [],
+    documentUrls: ['https://comix.to/title/x/1-chapter-1'],
+  });
+  let deniedError = null;
+  try { await denied.api.waitForInjectableTab(101, { timeoutMs: 5000 }); }
+  catch (error) { deniedError = error; }
+  check('An ungranted host permission fails fast with an actionable message',
+    deniedError && deniedError.code === 'HOST_PERMISSION_MISSING' &&
+    /comix\.to/.test(deniedError.message) &&
+    /permissions/i.test(deniedError.message) &&
+    denied.getInjectAttempts() === 1);
+  check('A denial is reported as a chapter extraction failure',
+    deniedError && deniedError.cdlKind === 'chapter_extraction');
+
+  // ── Tab closed mid-wait ────────────────────────────────────────────────────
+  const closed = buildHarness({ documentUrls: ['about:blank'] });
+  closed.closeTab();
+  let closedError = null;
+  try { await closed.api.waitForInjectableTab(101, { timeoutMs: 5000 }); }
+  catch (error) { closedError = error; }
+  check('A closed tab stops the wait instead of retrying to the deadline',
+    closedError && /No tab with id/.test(closedError.message) &&
+    closed.getInjectAttempts() === 1);
+
+  // ── Deadline ───────────────────────────────────────────────────────────────
+  const stuck = buildHarness({ documentUrls: ['about:blank'] });
+  let stuckError = null;
+  try { await stuck.api.waitForInjectableTab(101, { timeoutMs: 400 }); }
+  catch (error) { stuckError = error; }
+  check('A tab that never commits reports a load failure, not a permission failure',
+    stuckError && stuckError.code === 'INJECTION_NOT_READY' &&
+    !api.isHostPermissionError(stuckError));
+
+  // ── Stalled tab nudge ──────────────────────────────────────────────────────
+  // Firefox for Android unloads background tabs: the tab reports the chapter URL
+  // but holds no document, so waiting alone never succeeds.
+  const stalled = buildHarness({ documentUrls: ['about:blank'] });
+  let nudgeCount = 0;
+  const woken = await stalled.api.waitForInjectableTab(101, {
+    timeoutMs: 5000,
+    nudgeAfterMs: 100,
+    nudge: () => {
+      nudgeCount++;
+      stalled.commitDocument('https://comix.to/title/x/1-chapter-1');
+    },
+  });
+  check('An unloaded background tab is re-navigated exactly once', nudgeCount === 1);
+  check('The wait succeeds once the nudged tab commits its document',
+    woken && woken.url === 'https://comix.to/title/x/1-chapter-1');
+
+  const hopeless = buildHarness({ documentUrls: ['about:blank'] });
+  let nudgeError = null;
+  let hopelessNudges = 0;
+  try {
+    await hopeless.api.waitForInjectableTab(101, {
+      timeoutMs: 600, nudgeAfterMs: 100, nudge: () => { hopelessNudges++; },
+    });
+  } catch (error) { nudgeError = error; }
+  check('A nudge that does not help still surfaces the load failure',
+    nudgeError && nudgeError.code === 'INJECTION_NOT_READY' && hopelessNudges === 1);
+
+  // ── Cancellation ───────────────────────────────────────────────────────────
+  const cancellable = buildHarness({ documentUrls: ['about:blank'] });
+  let cancelError = null;
+  try {
+    await cancellable.api.waitForInjectableTab(101, {
+      timeoutMs: 5000,
+      cancelled: () => true,
+    });
+  } catch (error) { cancelError = error; }
+  check('A stopped Download All aborts the wait immediately',
+    cancelError && cancelError.code === 'DOWNLOAD_ALL_STOPPED' &&
+    cancellable.getInjectAttempts() === 0);
+
+  // ── Diagnostics ────────────────────────────────────────────────────────────
+  const diagnostics = buildDiagnosticsHarness();
+  const permissionDiagnostic = diagnostics.diagnosticDefinition(
+    new Error('Missing host permission for the tab'), '', 'extracting'
+  );
+  check('A raw host-permission failure is classified as a chapter extraction failure',
+    permissionDiagnostic.kind === 'chapter_extraction' &&
+    permissionDiagnostic.code === 'CDL-EXTRACT-003');
+  const emptyDiagnostic = diagnostics.diagnosticDefinition(
+    new Error('Aucune image trouvée dans ce chapitre'), 'chapter_extraction', 'extracting'
+  );
+  check('Extraction failures without a permission cause keep their own codes',
+    emptyDiagnostic.code === 'CDL-EXTRACT-002');
+  check('The permission code carries an actionable public message',
+    source.includes("diagnostic.code === 'CDL-EXTRACT-003'") &&
+    /Allow Comix Downloader to access it in the browser add-on permissions/.test(source));
+
+  console.log(`${passed} passed, ${failed} failed`);
+  if (failed) process.exit(1);
+}
+
+run().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## The bug

Chapter extraction failed on Firefox mobile with `Missing host permission for the tab`.

## Root cause

Chrome exposes a navigation target as `tabs.Tab.pendingUrl` and leaves `tabs.Tab.url` on the document that is *actually loaded*. Firefox has no `pendingUrl`: it publishes the target URL as `url` as soon as the navigation is requested. A freshly created background tab therefore reports `status: "complete"` **with the chapter URL** while it still holds its initial `about:blank` document.

`extractFromTab` already had a guard against injecting into `about:blank` — but the guard tested `tab.url`, which is exactly the field Firefox fills in early, so it never fired there. The injection landed on `about:blank`, which no host permission covers, and the browser reported it as a missing host permission.

Firefox for Android hit this on nearly every chapter because the extraction tab is opened in the background there *and* pushed back to the background by the mobile tab restore, so its load commits well after the first `"complete"` event.

## The fix

- Both extraction paths — Download All (`extractFromTab`) and single chapter (`handlePendingDownloadTabUpdated`) — now wait for a document the extension may actually read (`waitForInjectableTab`) before probing for a Cloudflare challenge and before injecting the extractor.
- The extractor injection itself goes through `executeScriptWhenInjectable`, which retries while the tab sits between documents.
- A tab that reports a page while holding no document at all — Firefox for Android unloads background tabs under memory pressure — is re-navigated once instead of waiting out the whole deadline.

Waiting stops early whenever it cannot help:

- A genuinely ungranted host permission (checked with `permissions.contains`) fails immediately with a new `CDL-EXTRACT-003` diagnostic and a message telling the user to grant site access, instead of being reported as an unreadable chapter.
- A tab that never commits reports a load failure (`INJECTION_NOT_READY`) rather than the browser's misleading permission wording.
- A closed tab or a stopped Download All aborts the wait at once.

## Tests

- New `tests/host-permission-injection.test.js` (23 checks): retry until the document commits, fast failure on a real denial, closed-tab and cancellation handling, the single stalled-tab nudge, deadline behaviour, and the diagnostic classification.
- `tests/error-diagnostics.test.js`, `tests/download-session.test.js` and `tests/download-confirmation.test.js` gained the new `HOST_PERMISSION_ERROR_RE` dependency in their `diagnosticDefinition` harnesses.
- Full suite (`node tests/*.test.js`, 35 files) passes.
- `web-ext lint --warnings-as-errors` on a hand-staged Firefox package: 0 errors, 0 notices, 0 warnings. The PowerShell build/validate steps could not run in this environment (no `pwsh`); CI covers them.

## Verification note

The retry path is what makes this robust regardless of which of the two Firefox conditions a given device hits, but the pending-URL race is the one that matches the reported symptom. Worth a check on a real Firefox Android device before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HAd6tZPnP43n4YkQQ4QsaF

---
_Generated by [Claude Code](https://claude.ai/code/session_01HAd6tZPnP43n4YkQQ4QsaF)_